### PR TITLE
[feat][common] FeignClient traceId 전파 및 AuthContext.getTraceId() 추가

### DIFF
--- a/src/main/java/com/firstticket/common/feign/FeignConfig.java
+++ b/src/main/java/com/firstticket/common/feign/FeignConfig.java
@@ -16,6 +16,7 @@ public class FeignConfig {
 
     private static final String HEADER_USER_ID = "X-User-Id";
     private static final String HEADER_USER_ROLE = "X-User-Role";
+    private static final String HEADER_TRACE_ID = "X-Trace-Id";
 
     @Bean
     @ConditionalOnMissingBean(ErrorDecoder.class)
@@ -30,6 +31,10 @@ public class FeignConfig {
                 HttpServletRequest request = attributes.getRequest();
                 requestTemplate.header(HEADER_USER_ID, request.getHeader(HEADER_USER_ID));
                 requestTemplate.header(HEADER_USER_ROLE, request.getHeader(HEADER_USER_ROLE));
+                String traceId = request.getHeader(HEADER_TRACE_ID);
+                if (traceId != null && !traceId.isBlank()) {
+                    requestTemplate.header(HEADER_TRACE_ID, traceId);
+                }
             }
         };
     }

--- a/src/main/java/com/firstticket/common/web/AuthContext.java
+++ b/src/main/java/com/firstticket/common/web/AuthContext.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -29,6 +30,7 @@ public final class AuthContext {
 
     private static final String HEADER_USER_ID   = "X-User-Id";
     private static final String HEADER_USER_ROLE = "X-User-Role";
+    private static final String HEADER_TRACE_ID = "X-Trace-Id";
 
     // 유틸리티 클래스 - 인스턴스 생성 금지
     private AuthContext() {}
@@ -91,6 +93,25 @@ public final class AuthContext {
             throw new BusinessException(CommonErrorCode.UNAUTHORIZED);
         }
         return attributes.getRequest();
+    }
+
+    /**
+     * 현재 요청에 포함된 X-Trace-Id 헤더 값을 반환
+     *
+     * Gateway의 TraceIdFilter가 주입한 값을 읽음
+     * Span이 null인 경우(Gateway 주입 생략) 또는 직접 호출(Gateway 우회) 시 빈 문자열 반환
+     * traceId 부재가 비즈니스 오류가 아니므로 예외 대신 Optional로 반환한다.
+     */
+    public static Optional<String> getTraceId() {
+        if (!(RequestContextHolder.getRequestAttributes()
+            instanceof ServletRequestAttributes attributes)) {
+            return Optional.empty();
+        }
+        String traceId = attributes.getRequest().getHeader(HEADER_TRACE_ID);
+        // 빈 문자열도 "없음"으로 취급
+        return (traceId != null && !traceId.isBlank())
+            ? Optional.of(traceId.trim())
+            : Optional.empty();
     }
 
     /**


### PR DESCRIPTION
## 🌱 설명

- `FeignConfig.RequestInterceptor`에 `X-Trace-Id` 헤더 전파 추가
- `AuthContext`에 `getTraceId(): Optional<String>` 메서드 추가
- 버전업은 하지 않았습니다.

Gateway의 `TraceIdFilter`가 모든 요청에 `X-Trace-Id` 헤더를 주입하고 있으나,
서비스 간 Feign 호출 시 해당 헤더가 전파되지 않아 분산 추적 체인이 끊어지는 문제를 해결합니다.

## 📌 관련 이슈

close #22

## 💻 커밋 유형

- [x] feat     : 새로운 기능 추가

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> ⚠️ **이 PR은 `common` 모듈 변경으로 전 서비스에 자동 적용됩니다.**

**1. `FeignConfig.java` — X-Trace-Id 헤더 전파 추가**
- Gateway가 Span null로 인해 헤더를 주입하지 못한 경우, 빈 헤더가 다운스트림으로 나가지 않도록 null/blank 체크 후 전파

**2. `AuthContext.java` — `getTraceId()` 메서드 추가**
- 반환 타입 `Optional<String>` 사용 — traceId 부재가 비즈니스 오류가 아니므로 예외 대신 Optional
- HTTP 요청 컨텍스트 밖(비동기 스레드, Kafka 컨슈머)에서 호출 시 `Optional.empty()` 반환

**팀원 사용 가이드**

로그에 traceId 포함:

```
log.warn("[trace={}] 처리 실패: {}",
    AuthContext.getTraceId().orElse("none"), errorCode);
```

Feign 호출 시 `X-Trace-Id`는 **별도 설정 없이 자동 전파**됩니다.

```
Service A --[X-Trace-Id 자동 포함]--> Service B
```